### PR TITLE
Debian10 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   - DOCKER_TAG=alpine-3.5-glibc
   - DOCKER_TAG=debian-8
   - DOCKER_TAG=debian-9
+  - DOCKER_TAG=debian-10
   - DOCKER_TAG=ubuntu-16.04
   - DOCKER_TAG=ubuntu-18.04
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Different docker images are available:
 | [Alpine 3.10]       | alpine-3.10-glibc | [![](https://images.microbadger.com/badges/image/jlesage/baseimage:alpine-3.10-glibc.svg)](http://microbadger.com/#/images/jlesage/baseimage:alpine-3.10-glibc "Get your own image badge on microbadger.com") |
 | [Debian 8]         | debian-8         | [![](https://images.microbadger.com/badges/image/jlesage/baseimage:debian-8.svg)](http://microbadger.com/#/images/jlesage/baseimage:debian-8/ "Get your own image badge on microbadger.com") |
 | [Debian 9]         | debian-9         | [![](https://images.microbadger.com/badges/image/jlesage/baseimage:debian-9.svg)](http://microbadger.com/#/images/jlesage/baseimage:debian-9/ "Get your own image badge on microbadger.com") |
+| [Debian 10]         | debian-10         | [![](https://images.microbadger.com/badges/image/jlesage/baseimage:debian-10.svg)](http://microbadger.com/#/images/jlesage/baseimage:debian-10/ "Get your own image badge on microbadger.com") |
 | [Ubuntu 16.04 LTS] | ubuntu-16.04     | [![](https://images.microbadger.com/badges/image/jlesage/baseimage:ubuntu-16.04.svg)](http://microbadger.com/#/images/jlesage/baseimage:ubuntu-16.04 "Get your own image badge on microbadger.com") |
 | [Ubuntu 18.04 LTS] | ubuntu-18.04     | [![](https://images.microbadger.com/badges/image/jlesage/baseimage:ubuntu-18.04.svg)](http://microbadger.com/#/images/jlesage/baseimage:ubuntu-18.04 "Get your own image badge on microbadger.com") |
 
@@ -64,6 +65,7 @@ Different docker images are available:
 [Alpine 3.10]: https://alpinelinux.org
 [Debian 8]: https://www.debian.org/releases/jessie/
 [Debian 9]: https://www.debian.org/releases/stretch/
+[Debian 10]: https://www.debian.org/releases/buster/
 [Ubuntu 16.04 LTS]: http://releases.ubuntu.com/16.04/
 [Ubuntu 18.04 LTS]: http://releases.ubuntu.com/18:04/
 

--- a/versions/debian-10
+++ b/versions/debian-10
@@ -1,0 +1,3 @@
+DOCKERFILE=Dockerfile.debian
+BASEIMAGE=debian:buster-slim
+S6_OVERLAY_ARCH=amd64


### PR DESCRIPTION
I've already built an image based on your baseimage-gui rebuilt for debian10 amd64.

There aren't any changes required to make docker-baseimage on debian10 work.

Not sure if this warrents a version bump in your opinion. Since there is no change to existing images when rebuilding. I just added debian-10 to versions, travis-ci and updated the readme.

Can make a pull request for baseimage-gui later. But I'll wait for a response on this one first. There might be something you want to be done differently for pull requests.