### PR TITLE
Make Docker secrets take precedence over environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ they follow the naming convention `CONT_ENV_<environment variable name>`.
 For example, a secret named `CONT_ENV_MY_PASSWORD` creates the environment
 variable `MY_PASSWORD` with the secret's content.
 
+A Docker secret always takes precedence over an environment variable of the
+same name, whether that variable was set by the Dockerfile or by the
+container's operator.
+
 ### User/Group IDs
 
 When mapping data volumes (using the `-v` flag of the `docker run` command),

--- a/rootfs/init
+++ b/rootfs/init
@@ -58,6 +58,12 @@ valid_env_var_name() {
 load_env_var() {
     var_name="$1"
     var_val="$2"
+    # An optional third argument, when non-empty, forces the variable to be
+    # set even if it is already set. This is used for Docker secrets, which
+    # should always take precedence: unlike other environment variable
+    # sources, `${parameter+word}` cannot tell a value coming from the
+    # Dockerfile/operator apart from one that was never set at all.
+    force="${3:-}"
     # Use the parameter expansion '${parameter+word}': we want to set
     # the environment variable only when *unset*. If the variable is
     # already set, with null or a value, we need to skip it.
@@ -66,7 +72,7 @@ load_env_var() {
     # Exception for the `HOME` environment variable: it is always set by Docker,
     # meaning there is no way to know if it was set during continer creation.
     var_test="$(eval echo \$\{"${var_name}"+x\})"
-    if [ -z "${var_test}" ] || [ "${var_name}" = "HOME" ] ; then
+    if [ -z "${var_test}" ] || [ "${var_name}" = "HOME" ] || [ -n "${force}" ]; then
         export "${var_name}"="${var_val}"
         echo "export ${var_name}=\"${var_val}\"" >> /tmp/.cont-env-internal
     fi
@@ -157,7 +163,7 @@ if [ -d /run/secrets ]; then
         fi
 
         echo "loading..." | log_script "${env_var_name}"
-        load_env_var "${env_var_name}" "$(head -n1 < "${fpath}")"
+        load_env_var "${env_var_name}" "$(head -n1 < "${fpath}")" force
     done <&3
     exec 3>&- # Close file descriptor.
     rm "${flist}"

--- a/tests/test_docker_secrets.bats
+++ b/tests/test_docker_secrets.bats
@@ -4,7 +4,7 @@ setup() {
     load setup_common
 
     echo "TEST_VAL" > "$TESTS_WORKDIR"/TEST_VAR
-    echo "USER_VAL" > "$TESTS_WORKDIR"/TEST_VAR_OVERRIDE
+    echo "SECRET_VAL" > "$TESTS_WORKDIR"/TEST_VAR_OVERRIDE
 
     DOCKER_EXTRA_OPTS=()
     DOCKER_EXTRA_OPTS+=("-e" "TEST_VAR_OVERRIDE=USER_VAL")
@@ -33,7 +33,7 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
-@test "Checking that environment variable is not loaded from docker secrets when overridden by user..." {
+@test "Checking that environment variable from docker secrets takes precedence over one set by the user..." {
     # Dump docker logs before proceeding to validations.
     echo "====================================================================="
     echo " DOCKER LOGS"
@@ -43,7 +43,7 @@ teardown() {
     echo " END DOCKER LOGS"
     echo "====================================================================="
 
-    run exec_container_daemon sh -c "cat /proc/1/environ | tr '\0' '\n' | grep '^TEST_VAR_OVERRIDE=USER_VAL'"
+    run exec_container_daemon sh -c "cat /proc/1/environ | tr '\0' '\n' | grep '^TEST_VAR_OVERRIDE=SECRET_VAL$'"
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Fixes jlesage/docker-baseimage-gui#196

### Problem

`load_env_var()` in `rootfs/init` only sets a variable when it is currently unset, using the `${var+x}` parameter expansion test. That works fine for the general container-env-var loading stage, but it breaks the Docker secrets flow for images (like `docker-baseimage-gui`) whose Dockerfile pre-declares a variable as an empty string for discovery purposes, e.g.:

```
ENV WEB_AUTHENTICATION_PASSWORD=
```

By the time the `cont-secrets` stage runs, `load_env_var` sees `WEB_AUTHENTICATION_PASSWORD` as already "set" (to `""`), so it silently skips loading the mounted `CONT_ENV_WEB_AUTHENTICATION_PASSWORD` secret. The secret is read from disk (visible in the container logs as `loading...`), but never actually applied. The same symptom has been reported against other images that share this baseimage (handbrake, makemkv, mkvtoolnix, qdirstat) in htpcBeginner/docker-traefik#69.

### Fix

Add an optional third argument to `load_env_var`, `force`, that when non-empty sets the variable regardless of whether it is already set. The `cont-secrets` stage now passes `force`, so a mounted secret always wins, whether the existing value came from the Dockerfile's own default or from an operator-supplied environment variable. Nothing else changes: variable loading in the `cont-env` stage is untouched, and containers with no secrets mounted behave exactly as before.

This does change one existing behavior: today, if the same variable is defined both as a secret and as an operator-set environment variable, the environment variable wins. After this change, the secret wins. This was discussed on the linked issue, and matches how Compose, Kubernetes and Swarm treat secrets as the more authoritative source for sensitive values.

### Changes

- `rootfs/init`: `load_env_var` accepts an optional `force` argument; the secrets-loading stage passes it.
- `tests/test_docker_secrets.bats`: updated the existing precedence test (and its fixture values, which previously used the same string for both the secret and the env var, so the assertion couldn't actually tell which one won) to assert the secret wins.
- `README.md`: documented the precedence.