### PR TITLE
Preserve explicitly requested primary supplementary group

### DIFF
--- a/rootfs/defaults/service/sgid
+++ b/rootfs/defaults/service/sgid
@@ -14,7 +14,6 @@ echo "${grps}" \
     | tr ',' '\n' \
     | grep -v '^$' \
     | grep -v '^0$' \
-    | grep -vw "${GROUP_ID}" \
     | sort -nub
 
 # vim:ft=sh:ts=4:sw=4:et:sts=4


### PR DESCRIPTION
## Summary

Preserve `GROUP_ID` in the supplementary group list when users explicitly include it in `SUP_GROUP_IDS`.

## Problem

The current service descriptor removes `GROUP_ID` unconditionally:

```sh
grep -vw "${GROUP_ID}"
```

Therefore, this explicit configuration:

```text
USER_ID=568
GROUP_ID=568
SUP_GROUP_IDS=568
```

starts the application with primary GID 568 but no supplementary groups:

```text
Gid:    568 568 568 568
Groups:
```

On a TrueNAS ZFS dataset using NFSv4 ACLs, the affected application required group 568 to also be present in the supplementary group list. File access consequently failed with `EACCES`.

A manual `docker exec -u 568:568` test was misleading because the process created by Docker had `Groups: 568` and bypassed this service descriptor.

## Change

Remove the unconditional `GROUP_ID` filter. Empty entries and group 0 remain filtered, and the resulting list remains numerically sorted and deduplicated.

This makes `SUP_GROUP_IDS` behave literally when a user explicitly requests the same ID as `GROUP_ID`.

## Validation

With:

```text
USER_ID=568
GROUP_ID=568
SUP_GROUP_IDS=568
```

the application process now starts with:

```text
Uid:    568 568 568 568
Gid:    568 568 568 568
Groups: 568
```

The corrected base behavior was validated through a derived `jlesage/mkvtoolnix` image deployed as a TrueNAS Custom App. MKVToolNix successfully opened the original affected file and completed a full remux.

Reproducing the original GUI credentials by explicitly clearing supplementary groups caused both `head` and `mkvmerge` to fail with `EACCES`. Restoring supplementary group 568 made both succeed.

Related investigation: jlesage/docker-mkvtoolnix#99
